### PR TITLE
Feature - secondary norminette command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Launch Quick Open with <kbd>⌘</kbd>+<kbd>P</kbd> and enter
 ext install codam-norminette
 ```
 
+If you want to integrate norminette+, check install instructions via bit.ly/norminette
+After installation, configure `codam-norminette.command2` in VSCode to point to norminette+ (default `python ~/norminette+/run.py`)
+
 ## Usage
 
-If there are changes to the file, the norm is automatically checked on save.
+If there are changes to the file, the norm is automatically checked on save
 
 
 ## Configuration
@@ -23,13 +26,15 @@ If there are changes to the file, the norm is automatically checked on save.
 ```ts
 {
   "codam-norminette.command": "norminette",
-  "codam-norminette.fileregex": "\\.[ch]$"
+  "codam-norminette.command2": "",
+  "codam-norminette.fileregex": "\\.[ch]$",
+  "codam-norminette.fileregex2": "(\\.[ch])|Makefile|makefile|GNUmakefile$"
 }
 ```
 
 ## Issues
 
-To report a bug or ask for a feature, please open a [Github issue](https://github.com/thijsdejong/vscode-codam-norminette/issues).
+To report a bug or ask for a feature, please open a [Github issue](https://github.com/thijsdejong/vscode-codam-norminette/issues)
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ ext install codam-norminette
 ```
 
 If you want to integrate norminette+, check install instructions via bit.ly/norminette
+
 After installation, configure `codam-norminette.command2` in VSCode to point to norminette+ (default `python ~/norminette+/run.py`)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -2,48 +2,58 @@
 	"name": "codam-norminette",
 	"displayName": "Codam Norminette",
 	"description": "Codam Norminette decorator for VSCode",
-	"version": "19.2.4",
+	"version": "19.9.1",
 	"publisher": "thijsdejong",
 	"license": "MIT",
 	"engines": {
-	  "vscode": "^1.6.0"
+		"vscode": "^1.6.0"
 	},
 	"categories": [
-	  "Other"
+		"Other"
 	],
 	"activationEvents": [
-	  "*"
+		"*"
 	],
 	"icon": "codam.png",
 	"main": "./out/extension",
 	"scripts": {
-	  "vscode:prepublish": "tsc -p ./",
-	  "compile": "tsc -watch -p ./",
-	  "postinstall": "node ./node_modules/vscode/bin/install"
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
-	  "@types/node": "*",
-	  "typescript": "^2.9.2",
-	  "vsce": "^1.51.0",
-	  "vscode": "^1.0.0"
+		"@types/node": "*",
+		"typescript": "^2.9.2",
+		"vsce": "^1.51.0",
+		"vscode": "^1.0.0"
 	},
 	"contributes": {
-	  "configuration": {
-		"type": "object",
-		"title": "Codam Norminette config",
-		"properties": {
-		  "codam-norminette.command": {
-			"type": "string",
-			"default": "norminette",
-			"description": "Specifies norminette command, example: > norminette -R CheckForbiddenSourceHeader < for Piscine Day00-09. \n defaults to norminette"
-		  },
-		  "codam-norminette.fileregex": {
-			"type": "string",
-			"default": "\\.[ch]$",
-			"description": "Specifies which c file to run norminette on \n defaults to \\.[ch]$"
-		  }
+		"configuration": {
+			"type": "object",
+			"title": "Codam Norminette config",
+			"properties": {
+				"codam-norminette.command": {
+					"type": "string",
+					"default": "norminette",
+					"description": "Specifies norminette command, example: > norminette -R CheckForbiddenSourceHeader < for Piscine Day00-09 \n defaults to norminette"
+				},
+				"codam-norminette.command2": {
+					"type": "string",
+					"default": "",
+					"description": "Specifies secondary norminette command, example: > python ~/norminette+/run.py < for norminette+ \n no default since not everyone has norminette+"
+				},
+				"codam-norminette.fileregex": {
+					"type": "string",
+					"default": "\\.[ch]$",
+					"description": "Specifies which c file to run norminette on \n defaults to \\.[ch]$"
+				},
+				"codam-norminette.fileregex2": {
+					"type": "string",
+					"default": "(\\.[ch])|Makefile|makefile|GNUmakefile$",
+					"description": "Specifies which files to run the secondary norminette command on \n defaults to (\\.[ch])|Makefile|makefile|GNUmakefile$"
+				}
+			}
 		}
-	  }
 	},
 	"repository": "https://github.com/thijsdejong/vscode-codam-norminette"
-  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,37 +36,59 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	function updateDecorations() {
-		if (!activeEditor || activeEditor.document.languageId !== "c") {
+		if (!activeEditor || (activeEditor.document.languageId !== "c" && activeEditor.document.languageId !== "makefile")) {
 			return
 		}
-
+		let command = vscode.workspace.getConfiguration('codam-norminette').get('command') as string;
+		let command2 = vscode.workspace.getConfiguration('codam-norminette').get('command2') as string;
 		let regex = vscode.workspace.getConfiguration('codam-norminette').get('fileregex') as string;
 		let pattern = RegExp(regex);
-		if(!activeEditor.document.uri.path.replace(/^.*[\\\/]/, '').match(pattern)) return;
+		let regex2 = vscode.workspace.getConfiguration('codam-norminette').get('fileregex2') as string;
+		let pattern2 = RegExp(regex2);
 
 		const errors: vscode.DecorationOptions[] = []
-		runNorminetteProccess(activeEditor.document.uri.path)
-			.then((data: Array<any>) => {
-				data.forEach(e => {
-					let range
-					let decoration
-					if (!e.col || !activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))) {
-						range = activeEditor.document.lineAt(e.line).range
-						decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
-					}
-					else {
-						range = activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))
-						decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
-					}
-					errors.push(decoration)
-				})
-				activeEditor.setDecorations(errorsDecoration, errors)
-			})
+		if (command && activeEditor.document.uri.path.replace(/^.*[\\\/]/, '').match(pattern)) {
+				runNorminetteProccess(activeEditor.document.uri.path, command)
+					.then((data: Array<any>) => {
+						data.forEach(e => {
+							let range
+							let decoration
+							if (!e.col || !activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))) {
+								range = activeEditor.document.lineAt(e.line).range
+								decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
+							}
+							else {
+								range = activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))
+								decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
+							}
+							errors.push(decoration)
+						})
+						activeEditor.setDecorations(errorsDecoration, errors)
+					})
+				}
+		if (command2 && activeEditor.document.uri.path.replace(/^.*[\\\/]/, '').match(pattern2)) {
+				runNorminetteProccess(activeEditor.document.uri.path, command2)
+					.then((data: Array<any>) => {
+						data.forEach(e => {
+							let range
+							let decoration
+							if (!e.col || !activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))) {
+								range = activeEditor.document.lineAt(e.line).range
+								decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
+							}
+							else {
+								range = activeEditor.document.getWordRangeAtPosition(new vscode.Position(e.line, e.col))
+								decoration = { range: range, hoverMessage: 'Error: **' + e.errorText + '**' }
+							}
+							errors.push(decoration)
+						})
+						activeEditor.setDecorations(errorsDecoration, errors)
+					})
+			}
 	}
 
-	function runNorminetteProccess(filename: String) {
+	function runNorminetteProccess(filename: String, command: String) {
 		console.log(filename)
-		let command = vscode.workspace.getConfiguration('codam-norminette').get('command');
 		return new Promise((resolve, reject) => {
 			const line = []
 			const normDecrypted = []


### PR DESCRIPTION
Added a command2 and fileregex2 option to be able to run a secondary command, like norminette+.
Modified documentation to reflect the new feature.
Module now explicitly checks for each command if it is non-empty before it runs the command.
Code could be improved since there is a bunch of reused code, but it's functional...

Also, not sure what happened to the indentation in package.json, seems my vscode wants tabs...